### PR TITLE
feat: update parquet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,23 +3,18 @@ name = "gorgon"
 version = "0.1.3"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 async-trait = "0.1"
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "sync", "time", "macros"] }
-
-serde = { version = "1", features = ["derive", "rc"] }
-
 tracing = "0.1"
 
 # Misc
 thiserror = "1.0"
 anyhow = "1"
 
-chrono = { version = "0.4", features = ["serde"] }
-aws-sdk-s3 = "0.24.0"
+chrono = { version = "0.4" }
+aws-sdk-s3 = "0.24"
 maxminddb = "0.23"
 bytes = "1.2"
-parquet = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "431abf5", default-features = false, features = ["flate2"]  }
-parquet_derive = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "431abf5" }
+parquet = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "4577a11", default-features = false, features = ["flate2"]  }
+parquet_derive = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "4577a11" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = "1.0"
 anyhow = "1"
 
 chrono = { version = "0.4" }
-aws-sdk-s3 = "0.24"
+aws-sdk-s3 = "0.25"
 maxminddb = "0.23"
 bytes = "1.2"
 parquet = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "4577a11", default-features = false, features = ["flate2"]  }

--- a/src/batcher/aws.rs
+++ b/src/batcher/aws.rs
@@ -1,7 +1,7 @@
 use {
     super::BatchExporter,
     async_trait::async_trait,
-    aws_sdk_s3::{types::ByteStream, Client},
+    aws_sdk_s3::{primitives::ByteStream, Client},
     chrono::{Datelike, Utc},
     std::{
         sync::Arc,

--- a/src/batcher/parquet.rs
+++ b/src/batcher/parquet.rs
@@ -34,7 +34,7 @@ where
 
     fn create(buffer: Buffer, opts: &BatchCollectorOpts) -> Result<Self, Self::Error> {
         let props = WriterProperties::builder()
-            .set_compression(Compression::GZIP)
+            .set_compression(Compression::GZIP(Default::default()))
             .build();
         let props = Arc::new(props);
         let schema = ([] as [T; 0]).schema()?;

--- a/src/batcher/tests.rs
+++ b/src/batcher/tests.rs
@@ -3,7 +3,6 @@ use {
     crate::Analytics,
     async_trait::async_trait,
     parquet_derive::ParquetRecordWriter,
-    serde::Serialize,
     std::time::Duration,
     tokio::sync::mpsc::{self, error::TrySendError},
 };
@@ -24,7 +23,7 @@ impl BatchExporter for MockExporter {
     }
 }
 
-#[derive(Serialize, ParquetRecordWriter)]
+#[derive(ParquetRecordWriter)]
 struct DataA {
     a: u32,
     b: &'static str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,25 @@
+use std::sync::Arc;
+
 pub use noop::*;
-use {serde::Serialize, std::sync::Arc};
 
 pub mod batcher;
 pub mod geoip;
 mod noop;
 pub mod time;
 
-#[derive(Clone)]
 pub struct Analytics<T>
 where
     T: AnalyticsEvent,
 {
     inner: Arc<dyn AnalyticsCollector<T>>,
+}
+
+impl<T: AnalyticsEvent> Clone for Analytics<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl<T> Analytics<T>
@@ -29,9 +37,9 @@ where
     }
 }
 
-pub trait AnalyticsEvent: 'static + Serialize + Send + Sync {}
+pub trait AnalyticsEvent: 'static + Send + Sync {}
 
-impl<T> AnalyticsEvent for T where T: 'static + Serialize + Send + Sync {}
+impl<T> AnalyticsEvent for T where T: 'static + Send + Sync {}
 
 pub trait AnalyticsCollector<T>: Send + Sync
 where


### PR DESCRIPTION
# Description

Changes:
- Updated `arrow-rs` parquet exporter (merged upstream changes);
- Removed `Clone` and `Serialize` requirements from `AnalyticsEvent`. This was required to implement reference counters around analytics events in the relay. Added benefit is there's less code generated, so should compile slightly faster.

## How Has This Been Tested?

Manually.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
