### PR TITLE
feat: log address lookup as warn not error

### DIFF
--- a/src/geoip.rs
+++ b/src/geoip.rs
@@ -68,7 +68,7 @@ impl GeoIpReader {
         self.reader
             .as_ref()?
             .lookup::<City>(addr)
-            .tap_err(|err| log::error!("geoip_city lookup error: {err}"))
+            .tap_err(|err| log::warn!("geoip_city lookup error: {err}"))
             .ok()
             .map(|city| AnalyticsGeoData {
                 city: city


### PR DESCRIPTION
# Description

This improves the experience in services to actually find errors. Sometimes geos cannot be looked up by design. This is not worth an error.

## How Has This Been Tested?

<!--
Please:
* describe the tests that you ran to verify your changes.
* provide instructions so we can reproduce.
-->

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
