### PR TITLE
fix: bump commit hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ chrono = { version = "0.4" }
 aws-sdk-s3 = "0.25"
 maxminddb = "0.23"
 bytes = "1.2"
-parquet = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "4577a11", default-features = false, features = ["flate2"]  }
-parquet_derive = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "4577a11" }
+parquet = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "99a1cc3", default-features = false, features = ["flate2"]  }
+parquet_derive = { git = "https://github.com/WalletConnect/arrow-rs.git", rev = "99a1cc3" }


### PR DESCRIPTION
# Description
Fixes gorgon by patching the arrow-rs commit hash due to merging upstream

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
