### PR TITLE
fix: blocking export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 async-trait = "0.1"
-tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "sync", "time", "macros"] }
+tokio = { version = "1", default-features = false, features = ["rt", "rt-multi-thread", "sync", "time", "macros"] }
 tracing = "0.1"
 
 # Misc

--- a/src/collectors/traits.rs
+++ b/src/collectors/traits.rs
@@ -4,18 +4,21 @@ use {
         AnalyticsEvent,
     },
     async_trait::async_trait,
-    std::fmt::{Debug, Display},
+    std::{
+        error::Error as StdError,
+        fmt::{Debug, Display},
+    },
 };
 
 #[async_trait]
 pub trait BatchExporter: 'static + Clone + Send {
-    type Error: Debug + Display;
+    type Error: StdError + Send + Sync + Debug + Display + 'static;
 
     async fn export(self, data: Vec<u8>) -> Result<(), Self::Error>;
 }
 
 pub trait BatchWriter<T: AnalyticsEvent>: 'static + Send + Sync + Sized {
-    type Error: Debug + Display;
+    type Error: StdError + Send + Sync + Debug + Display + 'static;
 
     fn create(buffer: BatchBuffer, opts: &BatchOpts) -> Result<Self, Self::Error>;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,7 +15,7 @@ struct MockExporter(mpsc::Sender<Vec<u8>>);
 
 #[async_trait]
 impl BatchExporter for MockExporter {
-    type Error = u32;
+    type Error = std::io::Error;
 
     async fn export(mut self, data: Vec<u8>) -> Result<(), Self::Error> {
         // Provide custom messages for clean log output.


### PR DESCRIPTION
# Description

This moves the `BatchWriter::into_buffer()` call to a separate thread when exporting. This should fix the `no available capacity` error we're seeing in the relay.

## How Has This Been Tested?

Untested.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
